### PR TITLE
CDXToSPDX: Build SPDX Document Namespace, Code Cleanup & Refactoring

### DIFF
--- a/cli/cmd/sbom/sbom.go
+++ b/cli/cmd/sbom/sbom.go
@@ -3,6 +3,7 @@ package sbom
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/spdx/tools-golang/spdx"
@@ -13,31 +14,44 @@ import (
 
 func ConvertToGoogleSPDX(bom *cdx.BOM) (*spdx.Document, error) {
 	spdxDoc := spdx.Document{
-		DocumentName:      bom.Metadata.Component.Name,
-		DocumentNamespace: "", // This needs to be a PURL?
-		SPDXVersion:       spdx.Version,
-		DataLicense:       "CC0-1.0",
-		CreationInfo: &v2_3.CreationInfo{
-			Created: bom.Metadata.Timestamp,
-			Creators: []common.Creator{{
-				Creator:     bom.Metadata.Component.Supplier.Name,
-				CreatorType: "Organization",
-			}},
-		},
+		SPDXVersion:    spdx.Version,
+		DataLicense:    "CC0-1.0",
 		SPDXIdentifier: toSPDXElementID("DOCUMENT"),
 	}
 
 	refMap := map[string]cdx.Component{}
 	typeMap := map[string]int{}
 
-	if bom.Metadata != nil && bom.Metadata.Component != nil {
-		if err := AddCycloneDXComponent(
-			*bom.Metadata.Component,
-			refMap,
-			typeMap,
-			&spdxDoc,
-		); err != nil {
-			return nil, fmt.Errorf("failed to add metadata component: %w", err)
+	if bom.Metadata != nil {
+		spdxDoc.CreationInfo = &v2_3.CreationInfo{
+			Created: bom.Metadata.Timestamp,
+		}
+		if bom.Metadata.Component != nil {
+			metaComp := bom.Metadata.Component
+			spdxDoc.DocumentName = metaComp.Name
+			if metaComp.Supplier != nil {
+				spdxDoc.CreationInfo.Creators = []common.Creator{{
+					Creator:     metaComp.Supplier.Name,
+					CreatorType: "Organization",
+				}}
+			}
+			if err := AddCycloneDXComponent(
+				*metaComp,
+				refMap,
+				typeMap,
+				&spdxDoc,
+			); err != nil {
+				return nil, fmt.Errorf("failed to add metadata component: %w", err)
+			}
+		}
+	}
+
+	// Build SPDX document namespace.
+	if spdxDoc.DocumentNamespace == "" {
+		serialNumber := strings.TrimPrefix(bom.SerialNumber, "urn:uuid:")
+		if serialNumber != "" && spdxDoc.DocumentName != "" {
+			spdxDoc.DocumentNamespace = fmt.Sprintf("http://spdx.org/spdxdocs/%s-%s",
+				spdxDoc.DocumentName, serialNumber)
 		}
 	}
 
@@ -59,37 +73,8 @@ func ConvertToGoogleSPDX(bom *cdx.BOM) (*spdx.Document, error) {
 		}
 	}
 
-	compTypeMap := map[string]int{}
-	assemblyDAG := map[string][]string{}
-	asmRefErr := 0
-	for _, c := range *bom.Compositions {
-		compType := "unknown"
-		switch {
-		case len(*c.Assemblies) != 0:
-			compType = "assembly"
-			// Let's parse the assembly
-			asmKey := string((*c.Assemblies)[0])
-			if _, ok := refMap[asmKey]; !ok {
-				asmRefErr++
-			}
-			v := assemblyDAG[asmKey]
-			for _, asm := range (*c.Assemblies)[1:] {
-				v = append(v, string(asm))
-			}
-		case len(*c.Dependencies) != 0:
-			compType = "dependency"
-		case len(*c.Vulnerabilities) != 0:
-			compType = "vulnerability"
-		}
-		compTypeMap[compType] += 1
-		if c.BOMRef != "" {
-			log.Infof("compos: %q", c.BOMRef)
-		}
-	}
-	log.Infof("Found %d Assembly ref errors", asmRefErr)
 	log.Infof("Loaded %d components from BOM", len(refMap))
 	log.Infof("TypeMap: %+v", typeMap)
-	log.Infof("CompMap: %+v", compTypeMap)
 	return &spdxDoc, nil
 }
 


### PR DESCRIPTION
This PR introduces the following changes:

1. SPDX Document Namespace Field:
As specified in the [SPDX v2.3 specification](https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#65-spdx-document-namespace-field), this PR constructs the document namespace URI using the document name and UUID (serial number) from [CycloneDX](https://cyclonedx.org/docs/1.6/json/#serialNumber). The URI follows the standard format using a default SPDX CreatorWebsite and PathToSpdx, resulting in a namespace like:
https://spdx.org/spdxdocs/documentName-uuid
According to the spec, https://spdx.org/spdxdocs can be used as the base URI if the creator does not have their own website or unknown.

2. Added nil checks to safely access BOM metadata when constructing DocumentName, CreationInfo, and other fields, preventing potential nil pointer dereferences.

3. Removed code related to CycloneDX compositions, which—according to the spec—are intended to capture the completeness of the BOM ([reference](https://cyclonedx.org/use-cases/compositions-components/)). This functionality is not yet implemented but is planned for future PRs